### PR TITLE
Documentation Update & Install Routine for MySQL

### DIFF
--- a/docs/readme.rst
+++ b/docs/readme.rst
@@ -64,4 +64,4 @@ Bots is licenced under GNU GENERAL PUBLIC LICENSE Version 3; for full
 text: http://www.gnu.org/copyleft/gpl.html
 
 .. _Henk-Jan Ebbers: http://bots.sourceforge.net/en/index.shtml
-.. _documentation: https://bots-edi.github.io/
+.. _documentation: https://bots-edi.github.io/bots

--- a/src/bots/config/bots.ini
+++ b/src/bots/config/bots.ini
@@ -22,7 +22,7 @@ maxruntime = 60
 #limit: number of (reports, orders) max displayed on one screen; default is 30
 limit = 30
 #adminlimit: number of lines displayed on one screen for configuration items; default is value of 'limit'
-#adminlimit = 30
+adminlimit = 30
 #interchangecontrolperpartner: if True: interchange control reference per receiver; if False: per sender. Default: False
 interchangecontrolperpartner=False
 #multiplevaluesasterisk: determines what to show for display of incoming messages when multiple values: '*' (True) or first encountered value (False). Default: True

--- a/src/bots/install/bots.ini
+++ b/src/bots/install/bots.ini
@@ -22,7 +22,7 @@ maxruntime = 60
 #limit: number of (reports, orders) max displayed on one screen; default is 30
 limit = 30
 #adminlimit: number of lines displayed on one screen for configuration items; default is value of 'limit'
-#adminlimit = 30
+adminlimit = 30
 #interchangecontrolperpartner: if True: interchange control reference per receiver; if False: per sender. Default: False
 interchangecontrolperpartner=False
 #multiplevaluesasterisk: determines what to show for display of incoming messages when multiple values: '*' (True) or first encountered value (False). Default: True


### PR DESCRIPTION
Small patch to redirect the readme file link to the github.io page to fix #32 until RTD decision is finalized/launched.

Addresses a commented out element in the `bots.ini` files that caused MySQL based installation to fail as unable to identify this value.