### PR TITLE
Updated cherrypy dependencies

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -19,7 +19,7 @@ Dependencies
 Always needed
     * Needs: python 2.6/2.7. Python 2.5 works but extra dependencies are needed. Python >= 3.0 does not work.
     * Needs: django >= 1.4.0, django <= 1.7.0
-    * Needs: cherrypy > 3.1.0
+    * Needs: cherrypy > 3.1.0, cherrypy < 9.0
 
 Optional
     * Genshi (when using templates/mapping to HTML).


### PR DESCRIPTION
we need to use cherrypy <9 because they then moved to cheroot.
This breaks wsgiserver import of bots-webserver.py

http://docs.cherrypy.org/en/latest/history.html#v9-0-0
